### PR TITLE
fix(installer): resolve version at build time for bunx compatibility

### DIFF
--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "start": "bun run src/index.ts",
-    "build": "bun build src/index.ts --outfile dist/index.js --target bun --minify && chmod +x dist/index.js",
+    "build": "bun build src/index.ts --outfile dist/index.js --target bun --minify --define '__VERSION__=\"'$(node -p \"require('./package.json').version\")'\"' && chmod +x dist/index.js",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "bun run build"
   },

--- a/packages/installer/src/utils/logger.ts
+++ b/packages/installer/src/utils/logger.ts
@@ -1,14 +1,25 @@
-import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
 import chalk from "chalk";
 import ora, { type Ora } from "ora";
 
-// Read version from package.json
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const packageJsonPath = join(__dirname, "../../package.json");
-const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
-export const VERSION = packageJson.version;
+// Version is injected at build time via --define, with fallback for dev mode
+declare const __VERSION__: string;
+
+function getVersion(): string {
+  if (typeof __VERSION__ !== "undefined") {
+    return __VERSION__;
+  }
+  // Dev mode: read from package.json (works when running from source)
+  try {
+    // Dynamic import path that won't be bundled
+    const pkgPath = new URL("../../package.json", import.meta.url);
+    const pkg = require(pkgPath.pathname);
+    return pkg.version;
+  } catch {
+    return "dev";
+  }
+}
+
+export const VERSION = getVersion();
 
 export const logger = {
   info: (message: string) => console.log(chalk.blue("ℹ"), message),


### PR DESCRIPTION
The bundled package failed when run via bunx because the relative path to package.json didn't resolve correctly in the temp directory. Now the version is injected at build time via --define, with a fallback to read package.json dynamically for local development.