### PR TITLE
fix(installer): add timeout to runtime detection commands

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+# Validate conventional commit format
+# Format: type(scope): description
+# Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
+
+commit_msg=$(cat "$1")
+
+# Skip merge commits
+if echo "$commit_msg" | grep -qE "^Merge "; then
+  exit 0
+fi
+
+# Skip release-please commits
+if echo "$commit_msg" | grep -qE "^chore\(main\): release"; then
+  exit 0
+fi
+
+# Conventional commit regex
+pattern="^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9-]+\))?: .+"
+
+if ! echo "$commit_msg" | head -1 | grep -qE "$pattern"; then
+  echo "commit-msg: Invalid commit message format"
+  echo ""
+  echo "Expected: type(scope): description"
+  echo "Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert"
+  echo ""
+  echo "Examples:"
+  echo "  feat(installer): add new feature"
+  echo "  fix(installer): resolve bug"
+  echo "  docs: update README"
+  echo ""
+  echo "Your message: $commit_msg"
+  exit 1
+fi


### PR DESCRIPTION
Shell commands for detecting Docker/OrbStack now have a 5-second timeout using Bun.spawn to prevent hanging when the daemon isn't responding, which commonly occurs over SSH connections.

If a command times out, it returns null and the runtime is treated as unavailable. The process is killed on timeout.