### PR TITLE
fix(installer): add timeouts to docker commands and fix version parsing

### DIFF
--- a/packages/installer/src/services/runtime.ts
+++ b/packages/installer/src/services/runtime.ts
@@ -119,7 +119,9 @@ async function detectOrbStack(): Promise<RuntimeStatus["orbstack"]> {
     if (running) {
       const versionResult = await runWithTimeout("orb version");
       if (versionResult?.exitCode === 0) {
-        version = versionResult.stdout.trim().split("\n")[0];
+        // Output is "Version: 2.0.5 (2000500)" - extract just the version number
+        const match = versionResult.stdout.match(/(\d+\.\d+\.\d+)/);
+        version = match ? match[1] : versionResult.stdout.trim().split("\n")[0];
       }
     }
   }


### PR DESCRIPTION
- Add 10-second timeout to docker info, ps, volume, image, and lsof commands
- Add 10-minute timeout to docker pull commands
- Fix orb version parsing to extract semver (was showing "vVersion: 2.0.5")
- Use Bun.spawn with proper process kill on timeout