### PR TITLE
docs: add CI/CD and Claude integration documentation to MAINTAINERS.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Description
+
+<!-- Provide a clear description of the changes in this PR -->
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+- [ ] CI/CD changes
+
+## Testing
+
+<!-- Describe the tests you ran and how to reproduce them -->
+
+- [ ] All existing tests pass
+- [ ] New tests added (if applicable)
+- [ ] Manual testing performed
+
+## Checklist
+
+- [ ] Code follows the repository's style guidelines
+- [ ] Self-review completed
+- [ ] Documentation updated (if needed)
+- [ ] No new warnings generated
+- [ ] Conventional Commits format used
+
+---
+
+@claude please review this PR

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -117,3 +117,154 @@ npm publish --access public -w packages/installer
 - TypeScript with strict mode
 - ESM modules (`"type": "module"`)
 - Bun runtime for development and testing
+
+## CI/CD Pipelines
+
+### Continuous Integration (ci.yml)
+
+Runs on every push to `main` and on all pull requests targeting `main`. Validates code quality and build integrity.
+
+**Validation Steps:**
+1. **Lint Check** - Runs Biome linter to ensure code style compliance
+2. **TypeScript Check** - Validates TypeScript types across the codebase
+3. **Security Scan** - Runs Semgrep static analysis to detect security vulnerabilities
+4. **Build Verification** - Compiles the installer package to ensure no build errors
+
+**Requirements:**
+- All checks must pass before PRs can be merged
+- Uses Bun for fast dependency installation and execution
+- Python 3.12 required for Semgrep security scanning
+
+### Continuous Deployment (cd.yml)
+
+Automatically publishes the installer package to npm when releases are created.
+
+**Trigger Conditions:**
+- Automatically: When a GitHub release is published
+- Manually: Via workflow_dispatch with optional tag selection
+
+**Deployment Steps:**
+1. Checkout release tag
+2. Install dependencies and run TypeScript checks
+3. Build the installer package
+4. Publish to npm registry as `@lekman/n8n-local-deploy`
+
+**Requirements:**
+- `NPM_TOKEN` secret must be configured in repository settings
+- Only publishes from tagged releases
+- Uses `--access public` for scoped package publishing
+
+### Release Management (release.yml)
+
+Automated release management using [release-please](https://github.com/googleapis/release-please).
+
+**How It Works:**
+1. Runs on every push to `main` branch
+2. Analyzes commits using [Conventional Commits](https://www.conventionalcommits.org/) format
+3. Automatically creates/updates a Release PR with:
+   - Version bump based on commit types (feat = minor, fix = patch)
+   - Updated CHANGELOG.md with categorized changes
+   - Updated package.json version
+
+**Changelog Sections:**
+- `feat:` → Features
+- `fix:` → Bug Fixes
+- `perf:` → Performance
+- `docs:` → Documentation
+- `chore:`, `refactor:`, `test:`, `ci:` → Hidden from changelog
+
+**Configuration:**
+- `release-please-config.json` - Package configuration and changelog settings
+- `.release-please-manifest.json` - Current version tracking
+
+### Auto-Approval Workflow (auto-release.yml)
+
+Automatically approves and merges release-please PRs that only contain version bump files.
+
+**How It Works:**
+1. Triggers after the Release workflow completes successfully
+2. Finds open PRs with the `autorelease: pending` label
+3. Verifies only allowed files changed:
+   - `package.json` (version bumps)
+   - `CHANGELOG.md` (release notes)
+   - `.release-please-manifest.json` (version manifest)
+4. Auto-approves the PR if validation passes
+5. Enables auto-merge with squash strategy
+
+**Safety Features:**
+- Only processes PRs with specific release-please label
+- Validates file changes to prevent unintended merges
+- Rejects PRs with unexpected file changes
+- Uses GitHub App token with minimal required permissions
+
+**Result:**
+- Release PRs are automatically merged once CI passes
+- Triggers CD pipeline to publish to npm
+- Fully automated release cycle from commit to npm publish
+
+### NPM Publishing
+
+Publishing happens automatically through the CD pipeline when:
+1. A release-please PR is merged to `main`
+2. GitHub automatically creates a release with the new version tag
+3. The `cd.yml` workflow detects the new release
+4. Package is built and published to npm as `@lekman/n8n-local-deploy`
+
+**Manual Publishing:**
+```bash
+task qa                # Run all QA checks first
+npm publish --access public -w packages/installer
+```
+
+## Claude Integration
+
+This repository uses [Claude Code](https://claude.ai/code) for AI-assisted development. Maintainers and contributors can leverage Claude for implementation help, code reviews, and documentation.
+
+### Using Claude on Issues
+
+**Tag Claude for Implementation:**
+Comment `@claude` on any issue to request implementation assistance. Claude will:
+- Analyze the issue requirements
+- Create a feature branch
+- Implement the requested changes
+- Provide a PR link for review
+
+**Assign Issues to Claude:**
+Assign issues directly to `@claude` for automatic implementation. Claude will begin work immediately upon assignment.
+
+**Example Workflow:**
+```markdown
+## Issue: Add new validation test
+
+@claude please implement IQ test for Cloudflare tunnel configuration
+```
+
+### Using Claude on Pull Requests
+
+**Request Code Reviews:**
+Tag `@claude` in a PR comment to request a thorough code review. Claude will analyze:
+- Code quality and best practices
+- Potential bugs or security issues
+- Performance considerations
+- Test coverage
+
+**Automatic Review Requests:**
+The PR template automatically requests Claude reviews by including `@claude` mention.
+
+**Example Usage:**
+```markdown
+@claude please review this implementation for security concerns
+```
+
+### Best Practices
+
+1. **Be Specific** - Provide clear requirements and context in issue descriptions
+2. **Use Conventional Commits** - Claude follows the repository's commit conventions
+3. **Review Claude's Work** - Always review PRs created by Claude before merging
+4. **Iterate** - Tag Claude again on PRs to request changes or improvements
+
+### Limitations
+
+- Claude cannot approve PRs (security restriction)
+- Claude cannot merge PRs (requires human approval)
+- Complex multi-step features may require human guidance


### PR DESCRIPTION
- Document CI workflow (linting, type checking, security, build)
- Document CD workflow (npm publishing on release)
- Document release-please automated release management
- Document auto-release workflow for automatic PR approval
- Add Claude integration section with usage examples
- Create PR template with automatic @claude review request

Closes #22